### PR TITLE
Remove add_project and delete_project MCP tools

### DIFF
--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -56,42 +56,6 @@ func registerProjectTools(srv *mcpserver.MCPServer, store *projects.Store, ss *s
 	state := &projectState{}
 
 	srv.AddTool(
-		mcp.NewTool("add_project",
-			mcp.WithDescription("Add or update a project mapping (name → directory path). "+
-				"The path should be an absolute path to the project's root directory."),
-			mcp.WithString("name",
-				mcp.Required(),
-				mcp.Description("Short identifier for the project, e.g. 'myapp'."),
-			),
-			mcp.WithString("path",
-				mcp.Required(),
-				mcp.Description("Absolute path to the project directory."),
-			),
-		),
-		func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			return handleAddProject(store, req)
-		},
-	)
-
-	srv.AddTool(
-		mcp.NewTool("delete_project",
-			mcp.WithDescription("Delete a project, its env injection mappings, and all its secrets. "+
-				"Call without 'confirm' first to see a summary of what will be deleted. "+
-				"This action is irreversible."),
-			mcp.WithString("name",
-				mcp.Required(),
-				mcp.Description("Project name to delete."),
-			),
-			mcp.WithBoolean("confirm",
-				mcp.Description("Set to true to confirm deletion. Without this the tool performs a dry run and shows what would be deleted."),
-			),
-		),
-		func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			return handleDeleteProject(store, ss, state, req)
-		},
-	)
-
-	srv.AddTool(
 		mcp.NewTool("list_projects",
 			mcp.WithDescription("List all configured projects with their paths and env injection mappings."),
 		),
@@ -144,72 +108,6 @@ func registerProjectTools(srv *mcpserver.MCPServer, store *projects.Store, ss *s
 			return handleRunInProject(ctx, store, ss, cfg, req)
 		},
 	)
-}
-
-func handleAddProject(store *projects.Store, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	name := req.GetString("name", "")
-	path := req.GetString("path", "")
-	if name == "" {
-		return nil, fmt.Errorf("name is required")
-	}
-	if path == "" {
-		return nil, fmt.Errorf("path is required")
-	}
-	if err := store.Add(name, path); err != nil {
-		return nil, err
-	}
-	return mcp.NewToolResultText(fmt.Sprintf("project %q saved (path: %s)", name, path)), nil
-}
-
-func handleDeleteProject(store *projects.Store, ss *secrets.Store, state *projectState, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	name := req.GetString("name", "")
-	if name == "" {
-		return nil, fmt.Errorf("name is required")
-	}
-
-	p, err := store.Get(name)
-	if err != nil {
-		return nil, err
-	}
-
-	secretKeys := ss.KeysForProject(name)
-
-	if !req.GetBool("confirm", false) {
-		type dryRun struct {
-			Warning string   `json:"warning"`
-			Project string   `json:"project"`
-			Path    string   `json:"path"`
-			Secrets []string `json:"secrets"`
-		}
-		out, _ := json.Marshal(dryRun{
-			Warning: "This action is irreversible. Call again with confirm:true to proceed.",
-			Project: p.Name,
-			Path:    p.Path,
-			Secrets: secretKeys,
-		})
-		return mcp.NewToolResultText(string(out)), nil
-	}
-
-	// Delete all project-scoped secrets first.
-	for _, k := range secretKeys {
-		if err := ss.Delete(k); err != nil {
-			return nil, fmt.Errorf("deleting secret %q: %w", k, err)
-		}
-	}
-
-	if err := store.Delete(name); err != nil {
-		return nil, err
-	}
-	if state.get() == name {
-		state.set("")
-	}
-
-	type result struct {
-		Deleted        string   `json:"deleted"`
-		SecretsDeleted []string `json:"secrets_deleted"`
-	}
-	out, _ := json.Marshal(result{Deleted: name, SecretsDeleted: secretKeys})
-	return mcp.NewToolResultText(string(out)), nil
 }
 
 func handleListProjects(store *projects.Store, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/server/projects_test.go
+++ b/internal/server/projects_test.go
@@ -30,65 +30,6 @@ func openTestSecretStore(t *testing.T) *secrets.Store {
 	return ss
 }
 
-func TestHandleDeleteProject_DryRun(t *testing.T) {
-	store := openTestProjectStore(t)
-	ss := openTestSecretStore(t)
-	state := &projectState{}
-	_ = store.Add("myapp", "/code/myapp")
-	_ = ss.Set("myapp::DB_URL", "postgres://localhost/myapp")
-
-	// No confirm flag → dry run.
-	res, err := handleDeleteProject(store, ss, state, toolReq(map[string]any{"name": "myapp"}))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	text := textContent(res)
-	if !strings.Contains(text, "irreversible") {
-		t.Errorf("expected warning in dry-run output, got: %s", text)
-	}
-	if !strings.Contains(text, "myapp::DB_URL") {
-		t.Errorf("expected secret key listed in dry-run output, got: %s", text)
-	}
-
-	// Project must still exist after dry run.
-	if _, err := store.Get("myapp"); err != nil {
-		t.Error("project should not be deleted after dry run")
-	}
-	if _, ok := ss.Get("myapp::DB_URL"); !ok {
-		t.Error("secret should not be deleted after dry run")
-	}
-}
-
-func TestHandleDeleteProject_Confirmed(t *testing.T) {
-	store := openTestProjectStore(t)
-	ss := openTestSecretStore(t)
-	state := &projectState{current: "myapp"}
-	_ = store.Add("myapp", "/code/myapp")
-	_ = ss.Set("myapp::DB_URL", "postgres://localhost/myapp")
-
-	res, err := handleDeleteProject(store, ss, state, toolReq(map[string]any{
-		"name":    "myapp",
-		"confirm": true,
-	}))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(textContent(res), "myapp") {
-		t.Errorf("unexpected result: %s", textContent(res))
-	}
-	if state.get() != "" {
-		t.Error("expected active project to be cleared after delete")
-	}
-
-	// Project and secret must be gone.
-	if _, err := store.Get("myapp"); err == nil {
-		t.Error("project should be deleted")
-	}
-	if _, ok := ss.Get("myapp::DB_URL"); ok {
-		t.Error("secret should be deleted along with project")
-	}
-}
-
 func TestHandleListProjects(t *testing.T) {
 	store := openTestProjectStore(t)
 	_ = store.Add("alpha", "/alpha")


### PR DESCRIPTION
## Summary

- Removes `add_project` and `delete_project` from the MCP server — projects are configured beforehand via the CLI only
- Drops the corresponding unit tests for the removed handlers

## Test plan

- [x] `just check` passes
- [x] Remaining project MCP tools (`list_projects`, `switch_project`, `get_current_project`, `run_in_project`) still work as expected