### PR TITLE
Add channel config option to prevent duplicate bot listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,20 @@ If `DISCORD_DEBUG_CHANNEL_ID` is configured, the full output of each cron run is
 Optional, non-sensitive settings live in `~/.config/nexus-ai/config.yaml`.
 
 ```yaml
+# Enable a communication channel. Supported values: telegram
+# The required Claude plugin args are added to the main interactive session only —
+# background subprocesses (cron jobs, run_in_project) do NOT get them, which
+# prevents multiple competing bot listeners from being spawned.
+channel: telegram
+
+# Extra arguments prepended to every claude invocation.
 claude_args:
   - --model
   - claude-opus-4-6
 ```
 
 `claude_args` are prepended to every invocation, so `nexus --verbose` would run Claude with `--model claude-opus-4-6 --verbose`.
+
+### Telegram channel
+
+Set `channel: telegram` to connect the main Claude session to your Telegram bot. This automatically adds `--channels plugin:telegram@claude-plugins-official` to the interactive process. Make sure the `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` secrets are configured.

--- a/cmd/nexus/main.go
+++ b/cmd/nexus/main.go
@@ -80,7 +80,13 @@ func main() {
 		fmt.Fprintln(os.Stderr, "nexus: loading config:", err)
 		os.Exit(1)
 	}
+	// claudeArgs are the base args passed to background subprocesses.
+	// They intentionally exclude channel args to avoid spawning multiple
+	// competing bot listeners.
 	claudeArgs := append(cfg.ClaudeArgs, os.Args[1:]...)
+	// mainClaudeArgs are the args for the interactive PTY process only.
+	// Channel args are prepended here so the main session connects to the channel.
+	mainClaudeArgs := append(channelArgs(cfg.Channel), claudeArgs...)
 
 	discordToken, _ := secretStore.Get("DISCORD_BOT_TOKEN")
 	discordChannel, _ := secretStore.Get("DISCORD_CHANNEL_ID")
@@ -149,7 +155,7 @@ func main() {
 	}
 	defer shutdown()
 
-	if err := w.Run(ctx, claude, claudeArgs, secretStore.Keys()); err != nil {
+	if err := w.Run(ctx, claude, mainClaudeArgs, secretStore.Keys()); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			os.Exit(exitErr.ExitCode())
 		}
@@ -229,5 +235,18 @@ func runSecretCmd(store *secrets.Store, ps *projects.Store, args []string) {
 	default:
 		fmt.Fprintf(os.Stderr, "nexus: unknown secret command %q\n", subArgs[0])
 		os.Exit(1)
+	}
+}
+
+// channelArgs returns the Claude CLI arguments needed to activate the given
+// channel. These are added only to the main interactive process — never to
+// background subprocesses — to prevent multiple listeners competing for the
+// same bot connection.
+func channelArgs(channel string) []string {
+	switch channel {
+	case "telegram":
+		return []string{"--channels", "plugin:telegram@claude-plugins-official"}
+	default:
+		return nil
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,12 @@ import (
 type Config struct {
 	// ClaudeArgs are extra arguments prepended to every `nexus` invocation.
 	ClaudeArgs []string `yaml:"claude_args"`
+
+	// Channel is an optional communication channel to enable.
+	// When set, the required Claude plugin args are added to the main
+	// interactive Claude process only — never to background subprocesses.
+	// Currently only "telegram" is supported.
+	Channel string `yaml:"channel"`
 }
 
 // Load reads ~/.config/nexus-ai/config.yaml. If the file does not exist an empty
@@ -51,6 +57,13 @@ func parse(raw []byte) (Config, error) {
 		if arg == "" {
 			return Config{}, fmt.Errorf("claude_args[%d]: empty string is not allowed", i)
 		}
+	}
+
+	switch cfg.Channel {
+	case "", "telegram":
+		// valid
+	default:
+		return Config{}, fmt.Errorf("channel: unsupported value %q (supported: telegram)", cfg.Channel)
 	}
 
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,6 +35,16 @@ func TestParse(t *testing.T) {
 			want:  Config{ClaudeArgs: []string{"--model", "claude-opus-4-6"}},
 		},
 		{
+			name:  "channel telegram",
+			input: "channel: telegram\n",
+			want:  Config{Channel: "telegram"},
+		},
+		{
+			name:    "channel unsupported",
+			input:   "channel: discord\n",
+			wantErr: `channel: unsupported value "discord"`,
+		},
+		{
 			name:    "unknown key",
 			input:   "unknown_key: value\n",
 			wantErr: "field unknown_key not found",
@@ -73,6 +83,9 @@ func TestParse(t *testing.T) {
 				if cfg.ClaudeArgs[i] != tt.want.ClaudeArgs[i] {
 					t.Errorf("ClaudeArgs[%d] = %q, want %q", i, cfg.ClaudeArgs[i], tt.want.ClaudeArgs[i])
 				}
+			}
+			if cfg.Channel != tt.want.Channel {
+				t.Errorf("Channel = %q, want %q", cfg.Channel, tt.want.Channel)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Introduces a top-level `channel` field in `config.yaml` (currently supports `"telegram"`)
- The `--channels plugin:telegram@claude-plugins-official` arg is now added only to the main interactive PTY process, not to background subprocesses (cron jobs, `run_in_project`)
- Previously, every spawned subprocess inherited the channel arg, causing multiple competing Telegram bot listeners — breaking message delivery

## Test plan

- [ ] `go test ./internal/config/...` passes (new `channel_telegram` and `channel_unsupported` cases added)
- [ ] `go build ./...` succeeds
- [ ] Update `~/.config/nexus-ai/config.yaml` to use `channel: telegram` and remove `--channels` from `claude_args`
- [ ] Verify Telegram messages are delivered reliably when cron jobs are running concurrently

🤖 Generated with [Claude Code](https://claude.com/claude-code)